### PR TITLE
Added disk size specification when source_iso

### DIFF
--- a/builder/cloudstack/config.go
+++ b/builder/cloudstack/config.go
@@ -58,8 +58,7 @@ type Config struct {
 	// instance. This option is only available (and also required) when using
 	// source_iso.
 	DiskOffering string `mapstructure:"disk_offering" required:"false"`
-	// The size (in GB) of the root disk of the new
-	// instance. This option is only available when using source_template.
+	// The size (in GB) of the root disk of the new instance.
 	DiskSize int64 `mapstructure:"disk_size" required:"false"`
 	// If `true` make a call to the CloudStack API, after loading image to
 	// cache, requesting to check and detach ISO file (if any) currently

--- a/builder/cloudstack/step_create_instance.go
+++ b/builder/cloudstack/step_create_instance.go
@@ -58,6 +58,7 @@ func (s *stepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 	if config.SourceISO != "" {
 		p.SetDiskofferingid(config.DiskOffering)
 		p.SetHypervisor(config.Hypervisor)
+		p.SetSize(config.DiskSize)
 	}
 
 	// If we use a template, set the root disk size.

--- a/docs-partials/builder/cloudstack/Config-not-required.mdx
+++ b/docs-partials/builder/cloudstack/Config-not-required.mdx
@@ -24,8 +24,7 @@
   instance. This option is only available (and also required) when using
   source_iso.
 
-- `disk_size` (int64) - The size (in GB) of the root disk of the new
-  instance. This option is only available when using source_template.
+- `disk_size` (int64) - The size (in GB) of the root disk of the new instance.
 
 - `eject_iso` (bool) - If `true` make a call to the CloudStack API, after loading image to
   cache, requesting to check and detach ISO file (if any) currently

--- a/docs/builders/cloudstack.mdx
+++ b/docs/builders/cloudstack.mdx
@@ -99,8 +99,7 @@ builder.
   instance. This option is only available (and also required) when using
   `source_iso`.
 
-- `disk_size` (number) - The size (in GB) of the root disk of the new
-  instance. This option is only available when using `source_template`.
+- `disk_size` (number) - The size (in GB) of the root disk of the new instance.
 
 - `expunge` (boolean) - Set to `true` to expunge the instance when it is
   destroyed. Defaults to `false`.


### PR DESCRIPTION
This PR allows the disk size to be specified during source_iso.

The "deployVirtualMachine" API requires a "size" specification if you specify ISO format for "templateid".

If size is not specified, CloudStack return the following error:
```
$ cat example-cloudstack.pkr.hcl
packer {
  required_plugins {
    cloudstack = {
      version = ">= 1.0.0"
      source  = "github.com/hashicorp/cloudstack"
    }
  }
}

source "cloudstack" "example" {
  api_key          = "your api key"
  api_url          = "https://your cloudstack url/client/api"
  network          = "your network"
  secret_key       = "your secret"
  service_offering = "example-offering"
  ssh_username     = "root"
  source_iso            = "xxxxxxxx-123d-479c-916b-180beee6ccd9"
  hypervisor            = "VMware"
  disk_offering         = "xxxxxxxx-05e2-444a-8188-cc0669a04055"
  template_display_text = "Test Template"
  template_name         = "Test Template"
  template_os           = "xxxxxxxx-9402-11e9-acf6-1e00f4000240"
  zone                  = "xxxxxxxx-cc46-48a8-8cc5-3c172b74e408"
  expunge               = true
}

build {
  sources = ["source.cloudstack.example"]
}
```
```
$ packer build example-cloudstack.pkr.hcl
cloudstack.example: output will be in this color.

<<snip>>

==> Some builds didn't complete successfully and had errors:
--> cloudstack.example: Error creating new instance packer-6268ad4a-30f3-be83-a47e-16c1f5f164ec: CloudStack API error 431 (CSExceptionErrorCode: 4350): This disk offering requires a custom size specified
```

In this PR, specifying "disk_size" sets it to "Size" of deployVirtualMachine.
The original parameter "disk_size", which was only available when "source_template" was specified, has changed.