### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs/builders/cloudstack.mdx
+++ b/docs/builders/cloudstack.mdx
@@ -44,7 +44,7 @@ segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 ### Required:
@@ -175,7 +175,7 @@ builder.
   `packer_<UUID>`, where &lt;UUID&gt; is a 36 character unique identifier.
 
 - `user_data` (string) - User data to launch with the instance. This is a
-  [template engine](/docs/templates/legacy_json_templates/engine) see _User
+  [template engine](/packer/docs/templates/legacy_json_templates/engine) see _User
   Data_ below for more details. Packer will not automatically wait for a user
   script to finish before shutting down the instance this must be handled in a
   provisioner.


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them