### PR TITLE
docs: fix link to packer docs

### DIFF
--- a/docs/builders/cloudstack.mdx
+++ b/docs/builders/cloudstack.mdx
@@ -182,7 +182,7 @@ builder.
 
 - `user_data_file` (string) - Path to a file that will be used for the user
   data when launching the instance. This file will be parsed as a [template
-  engine](/docs/templates/legacy_json_templates/engine) see _User Data_ below
+  engine](/packer/docs/templates/legacy_json_templates/engine) see _User Data_ below
   for more details.
 
 - `use_local_ip_address` (boolean) - Set to `true` to indicate that the


### PR DESCRIPTION
The last PR forgot to update a link for the new dev site, this PR fixes this.