### PR TITLE
bump go 1.18 to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-cloudstack
 
-go 1.18
+go 1.19
 
 require (
 	github.com/apache/cloudstack-go/v2 v2.12.0


### PR DESCRIPTION
- go.mod: bump go version from 1.18 to 1.19
